### PR TITLE
feat: terminal session keepalive

### DIFF
--- a/service/rpc/io_stream.go
+++ b/service/rpc/io_stream.go
@@ -135,6 +135,20 @@ LOOP:
 		}
 	}()
 
+	go keepAlive(stream)
+
 	<-endCh
 	return err
+}
+
+func keepAlive(stream *ioStreamContext) {
+        ticker := time.NewTicker(20 * time.Second)
+        defer ticker.Stop()
+
+        for range ticker.C {
+                _, err := stream.agentIo.Write([]byte("\n"))
+                if err != nil {
+                        return
+                }
+        }
 }


### PR DESCRIPTION
Add a new function `keepAlive` to send a garbage byte to agent every 20 seconds.
This could be useful on server proxied by Cloudflare (it has a 60s timeout)